### PR TITLE
Get all of a user's connections endpoint is complete

### DIFF
--- a/denogres-gui/api/controllers/userConnections.ts
+++ b/denogres-gui/api/controllers/userConnections.ts
@@ -1,0 +1,14 @@
+import { Context } from "https://deno.land/x/oak@v11.1.0/context.ts";
+import { allConnections } from "../services/dbService.ts";
+
+export default async (ctx: Context) => {
+  const userID: string = await ctx.cookies.get('userId')
+  if (!userID) {
+    ctx.response.status = 401;
+    ctx.response.body = "Please log in to view your connections";
+  }
+  const connectionList = await allConnections(userID);
+  ctx.response.status = 200;
+  ctx.response.body = connectionList;
+  return;
+};

--- a/denogres-gui/api/repositories/userRepo.ts
+++ b/denogres-gui/api/repositories/userRepo.ts
@@ -37,9 +37,19 @@ export const addConnection = async (userID: string, connectionName: string): Pro
   
 }
 
+// get all connections for a user
+export const getAllConnections = async (userID: string): Promise<any> => {
+  const result = await client.queryObject({
+    text: "SELECT * FROM connections WHERE user_id=$1",
+    args: [userID]
+  })
+  return result.rows;
+}
+
 // addQuery
 
 export default { 
   checkUser,
-  checkPW
+  checkPW,
+  getAllConnections,
 };

--- a/denogres-gui/api/routes.ts
+++ b/denogres-gui/api/routes.ts
@@ -14,7 +14,7 @@ router
   .get('/api/columns/:table', columnNames)
   
   // route to return list of user's connections
-  .post('/api/allConnections', userConnections)
+  .get('/api/allConnections', userConnections)
   
   // user db routes:
   .post('/api/signin', signIn)

--- a/denogres-gui/api/routes.ts
+++ b/denogres-gui/api/routes.ts
@@ -3,6 +3,7 @@ import columnNames from "./controllers/columnNames.ts";
 import getTables from "./controllers/getTables.ts";
 import getConstraints from "./controllers/getConstraints.ts"
 import signIn from "./controllers/signIn.ts";
+import userConnections from "./controllers/userConnections.ts";
 
 const router = new Router();
 
@@ -12,8 +13,8 @@ router
   .get('/api/constraints', getConstraints)
   .get('/api/columns/:table', columnNames)
   
-  // route to set working db:
-  //.put('/api/')
+  // route to return list of user's connections
+  .post('/api/allConnections', userConnections)
   
   // user db routes:
   .post('/api/signin', signIn)

--- a/denogres-gui/api/services/dbService.ts
+++ b/denogres-gui/api/services/dbService.ts
@@ -1,2 +1,11 @@
+import { getAllConnections } from "../repositories/userRepo.ts";
+
+export const allConnections = async (userID: string) => {
+  const userConnections = await getAllConnections(userID);
+  return userConnections;
+}
 
 
+export default {
+  allConnections
+};


### PR DESCRIPTION
GET to /api/allConnections - returns and array of all connections and their information.

MUST be logged in and have the UserId cookie in order for this to work. If you want to test it in Postman, you can set a cookie value manually. UserId of 11 has a couple different connections saved on their account. 